### PR TITLE
Refactor gateway: RestClient migration and DNS resolve endpoint

### DIFF
--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -55,6 +55,16 @@
             <artifactId>resilience4j-spring-boot4</artifactId>
             <version>2.4.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/gateway/src/main/java/com/steadybit/demo/shopping/gateway/DnsController.java
+++ b/gateway/src/main/java/com/steadybit/demo/shopping/gateway/DnsController.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2026 steadybit GmbH. All rights reserved.
+ */
+
+package com.steadybit.demo.shopping.gateway;
+
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
+import jakarta.annotation.PreDestroy;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioDatagramChannel;
+import io.netty.resolver.dns.DnsNameResolver;
+import io.netty.resolver.dns.DnsNameResolverBuilder;
+import io.netty.resolver.dns.NoopDnsCache;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.InetAddress;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/dns")
+public class DnsController {
+
+    private final DnsNameResolver resolver;
+
+    public DnsController() {
+        this.resolver = new DnsNameResolverBuilder(new NioEventLoopGroup(1).next())
+                .channelType(NioDatagramChannel.class)
+                .resolveCache(NoopDnsCache.INSTANCE)
+                .queryTimeoutMillis(5000)
+                .build();
+    }
+
+    @PreDestroy
+    void close() {
+        resolver.close();
+    }
+
+    @PostMapping("/resolve/{hostname}")
+    @RateLimiter(name = "dnsResolve")
+    public DnsResult resolve(@PathVariable String hostname) {
+        try {
+            List<String> addresses = resolver.resolveAll(hostname).get().stream()
+                    .map(InetAddress::getHostAddress)
+                    .toList();
+            return new DnsResult(hostname, addresses, null);
+        } catch (Exception e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            return new DnsResult(hostname, List.of(), cause.getMessage());
+        }
+    }
+
+    public record DnsResult(String hostname, List<String> addresses, String error) {}
+}

--- a/gateway/src/main/java/com/steadybit/demo/shopping/gateway/GatewayApplication.java
+++ b/gateway/src/main/java/com/steadybit/demo/shopping/gateway/GatewayApplication.java
@@ -7,13 +7,11 @@ package com.steadybit.demo.shopping.gateway;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
-import org.springframework.web.reactive.config.WebFluxConfigurer;
 import org.springframework.web.reactive.function.client.WebClient;
 
 @SpringBootApplication
-public class GatewayApplication implements WebFluxConfigurer {
+public class GatewayApplication {
 
     @Value("${server.port}")
     private int serverPort;
@@ -24,11 +22,6 @@ public class GatewayApplication implements WebFluxConfigurer {
     @Bean
     public WebClient webClient() {
         return WebClient.builder().baseUrl("http://localhost:" + this.serverPort).build();
-    }
-
-    @Bean
-    public RestTemplateBuilder restTemplateBuilder() {
-        return new RestTemplateBuilder();
     }
 
 }

--- a/gateway/src/main/java/com/steadybit/demo/shopping/gateway/HealthController.java
+++ b/gateway/src/main/java/com/steadybit/demo/shopping/gateway/HealthController.java
@@ -5,13 +5,13 @@
 package com.steadybit.demo.shopping.gateway;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.restclient.RestTemplateBuilder;
-import org.springframework.http.HttpMethod;
+import org.springframework.boot.http.client.ClientHttpRequestFactoryBuilder;
+import org.springframework.boot.http.client.HttpClientSettings;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
-import org.springframework.web.client.RestTemplate;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -25,7 +25,7 @@ import java.util.concurrent.ConcurrentHashMap;
 @RestController
 @RequestMapping("/api/health")
 public class HealthController {
-    private final RestTemplate restTemplate;
+    private final RestClient restClient;
 
     @Value("${rest.endpoint.fashion}")
     private String urlFashion;
@@ -68,10 +68,12 @@ public class HealthController {
     @Value("${health.notification.port:8087}")
     private int notificationPort;
 
-    public HealthController(RestTemplateBuilder restTemplateBuilder) {
-        this.restTemplate = restTemplateBuilder
-                .connectTimeout(Duration.ofMillis(500))
-                .readTimeout(Duration.ofMillis(500))
+    public HealthController(RestClient.Builder restClientBuilder) {
+        this.restClient = restClientBuilder
+                .requestFactory(ClientHttpRequestFactoryBuilder.detect().build(
+                        HttpClientSettings.defaults()
+                                .withConnectTimeout(Duration.ofMillis(500))
+                                .withReadTimeout(Duration.ofMillis(500))))
                 .build();
     }
 
@@ -118,7 +120,7 @@ public class HealthController {
 
     private DependencyStatus checkHttp(String url) {
         try {
-            restTemplate.exchange(url, HttpMethod.GET, null, String.class);
+            restClient.get().uri(url).retrieve().body(String.class);
             return new DependencyStatus("UP", url, null);
         } catch (RestClientResponseException e) {
             return new DependencyStatus("UP", url, null);

--- a/gateway/src/main/java/com/steadybit/demo/shopping/gateway/ProductsController.java
+++ b/gateway/src/main/java/com/steadybit/demo/shopping/gateway/ProductsController.java
@@ -9,14 +9,14 @@ import com.steadybit.shopping.domain.Products;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.restclient.RestTemplateBuilder;
+import org.springframework.boot.http.client.ClientHttpRequestFactoryBuilder;
+import org.springframework.boot.http.client.HttpClientSettings;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpMethod;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -28,8 +28,8 @@ import java.util.List;
 @RequestMapping("/products")
 public class ProductsController {
     private static final Logger log = LoggerFactory.getLogger(GatewayApplication.class);
-    private final RestTemplate restTemplateWithoutTimeout;
-    private final RestTemplate restTemplate;
+    private final RestClient restClientWithoutTimeout;
+    private final RestClient restClient;
     private final WebClient webClient;
     private final ParameterizedTypeReference<Product> productTypeReference = new ParameterizedTypeReference<Product>() {
     };
@@ -44,9 +44,14 @@ public class ProductsController {
     @Value("${rest.endpoint.hotdeals}")
     private String urlHotDeals;
 
-    public ProductsController(RestTemplateBuilder restTemplateBuilder, WebClient webClient, Resilience4jProductService resilience4jProductService) {
-        this.restTemplate = restTemplateBuilder.connectTimeout(Duration.ofSeconds(2)).readTimeout(Duration.ofSeconds(2)).build();
-        this.restTemplateWithoutTimeout = restTemplateBuilder.build();
+    public ProductsController(RestClient.Builder restClientBuilder, WebClient webClient, Resilience4jProductService resilience4jProductService) {
+        this.restClientWithoutTimeout = restClientBuilder.build();
+        this.restClient = restClientBuilder.clone()
+                .requestFactory(ClientHttpRequestFactoryBuilder.detect().build(
+                        HttpClientSettings.defaults()
+                                .withConnectTimeout(Duration.ofSeconds(2))
+                                .withReadTimeout(Duration.ofSeconds(2))))
+                .build();
         this.webClient = webClient;
         this.resilience4jProductService = resilience4jProductService;
     }
@@ -107,7 +112,7 @@ public class ProductsController {
     }
 
     private List<Product> getProduct(String url) {
-        return this.restTemplateWithoutTimeout.exchange(url, HttpMethod.GET, null, this.productListTypeReference).getBody();
+        return this.restClientWithoutTimeout.get().uri(url).retrieve().body(this.productListTypeReference);
     }
 
     private List<Product> getProductBasicExceptionHandling(String url) {
@@ -121,7 +126,7 @@ public class ProductsController {
 
     private List<Product> getProductWithTimeout(String url) {
         try {
-            return this.restTemplate.exchange(url, HttpMethod.GET, null, this.productListTypeReference).getBody();
+            return this.restClient.get().uri(url).retrieve().body(this.productListTypeReference);
         } catch (RestClientException e) {
             log.error("RestClientException occurred when fetching products", e);
             return Collections.emptyList();

--- a/gateway/src/main/java/com/steadybit/demo/shopping/gateway/ProxyController.java
+++ b/gateway/src/main/java/com/steadybit/demo/shopping/gateway/ProxyController.java
@@ -2,8 +2,6 @@ package com.steadybit.demo.shopping.gateway;
 
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.restclient.RestTemplateBuilder;
-import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
@@ -12,16 +10,16 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.servlet.view.RedirectView;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 
 @Controller
 public class ProxyController {
-    private final RestTemplate restTemplate;
+    private final RestClient restClient;
 
     @Value("${rest.endpoint.checkout}")
     private String urlCheckout;
@@ -29,9 +27,8 @@ public class ProxyController {
     @Value("${rest.endpoint.inventory}")
     private String urlInventory;
 
-
-    public ProxyController(RestTemplateBuilder restTemplateBuilder) {
-        this.restTemplate = restTemplateBuilder.build();
+    public ProxyController(RestClient.Builder restClientBuilder) {
+        this.restClient = restClientBuilder.build();
     }
 
     @RequestMapping("/") public RedirectView indexRedirect() {
@@ -63,15 +60,21 @@ public class ProxyController {
         if (path.startsWith("/") && baseUrl.endsWith("/")) {
             path = path.substring(1);
         }
-        if (request.getQueryString()!=null) {
+        if (request.getQueryString() != null) {
             path += "?" + request.getQueryString();
         }
         var uri = new URI(baseUrl + path);
-        var httpEntity = new HttpEntity<>(body, headers);
-        try {
-            return restTemplate.exchange(uri, method, httpEntity, String.class);
-        } catch (HttpClientErrorException e) {
-            return ResponseEntity.status(e.getStatusCode()).body(e.getResponseBodyAsString());
+        var requestSpec = restClient.method(method)
+                .uri(uri)
+                .headers(h -> h.addAll(headers));
+        if (body != null) {
+            requestSpec.body(body);
         }
+        return requestSpec.exchange((req, response) -> {
+            var responseBody = new String(response.getBody().readAllBytes(), StandardCharsets.UTF_8);
+            return ResponseEntity.status(response.getStatusCode())
+                    .headers(response.getHeaders())
+                    .body(responseBody);
+        });
     }
 }

--- a/gateway/src/main/java/com/steadybit/demo/shopping/gateway/Resilience4jProductService.java
+++ b/gateway/src/main/java/com/steadybit/demo/shopping/gateway/Resilience4jProductService.java
@@ -10,11 +10,11 @@ import io.github.resilience4j.retry.annotation.Retry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.restclient.RestTemplateBuilder;
+import org.springframework.boot.http.client.ClientHttpRequestFactoryBuilder;
+import org.springframework.boot.http.client.HttpClientSettings;
 import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
+import org.springframework.web.client.RestClient;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -31,45 +31,50 @@ public class Resilience4jProductService {
     @Value("${rest.endpoint.hotdeals}")
     private String urlHotDeals;
 
-    private final RestTemplate restTemplate;
+    private final RestClient restClient;
     private final ParameterizedTypeReference<List<Product>> productListTypeReference = new ParameterizedTypeReference<List<Product>>() {
     };
 
-    public Resilience4jProductService(RestTemplateBuilder restTemplateBuilder) {
-        this.restTemplate = restTemplateBuilder.connectTimeout(Duration.ofSeconds(2)).readTimeout(Duration.ofSeconds(2)).build();
+    public Resilience4jProductService(RestClient.Builder restClientBuilder) {
+        this.restClient = restClientBuilder
+                .requestFactory(ClientHttpRequestFactoryBuilder.detect().build(
+                        HttpClientSettings.defaults()
+                                .withConnectTimeout(Duration.ofSeconds(2))
+                                .withReadTimeout(Duration.ofSeconds(2))))
+                .build();
     }
 
     @Retry(name = "fashion", fallbackMethod = "getProductsFallbackRetry")
     public List<Product> getFashionWithRetry() {
-        return this.restTemplate.exchange(this.urlFashion, HttpMethod.GET, null, this.productListTypeReference).getBody();
+        return this.restClient.get().uri(this.urlFashion).retrieve().body(this.productListTypeReference);
     }
 
     @Retry(name = "toys", fallbackMethod = "getProductsFallbackRetry")
     public List<Product> getToysWithRetry() {
-        return this.restTemplate.exchange(this.urlToys, HttpMethod.GET, null, this.productListTypeReference).getBody();
+        return this.restClient.get().uri(this.urlToys).retrieve().body(this.productListTypeReference);
     }
 
     @Retry(name = "hotdeals", fallbackMethod = "getProductsFallbackRetry")
     public List<Product> getHotDealsWithRetry() {
-        return this.restTemplate.exchange(this.urlHotDeals, HttpMethod.GET, null, this.productListTypeReference).getBody();
+        return this.restClient.get().uri(this.urlHotDeals).retrieve().body(this.productListTypeReference);
     }
 
     @Retry(name = "fashion", fallbackMethod = "getProductsFallbackRetry")
     @CircuitBreaker(name = "fashion", fallbackMethod = "getProductsFallbackCircuitBreaker")
     public List<Product> getFashionWithRetryAndCircuitBreaker() {
-        return this.restTemplate.exchange(this.urlFashion, HttpMethod.GET, null, this.productListTypeReference).getBody();
+        return this.restClient.get().uri(this.urlFashion).retrieve().body(this.productListTypeReference);
     }
 
     @Retry(name = "toys", fallbackMethod = "getProductsFallbackRetry")
     @CircuitBreaker(name = "toys", fallbackMethod = "getProductsFallbackCircuitBreaker")
     public List<Product> getToysWithRetryAndCircuitBreaker() {
-        return this.restTemplate.exchange(this.urlToys, HttpMethod.GET, null, this.productListTypeReference).getBody();
+        return this.restClient.get().uri(this.urlToys).retrieve().body(this.productListTypeReference);
     }
 
     @Retry(name = "hotdeals", fallbackMethod = "getProductsFallbackRetry")
     @CircuitBreaker(name = "hotdeals", fallbackMethod = "getProductsFallbackCircuitBreaker")
     public List<Product> getHotDealsWithRetryAndCircuitBreaker() {
-        return this.restTemplate.exchange(this.urlHotDeals, HttpMethod.GET, null, this.productListTypeReference).getBody();
+        return this.restClient.get().uri(this.urlHotDeals).retrieve().body(this.productListTypeReference);
     }
 
     private List<Product> getProductsFallbackRetry(RuntimeException exception) {

--- a/gateway/src/main/resources/application.yml
+++ b/gateway/src/main/resources/application.yml
@@ -29,6 +29,12 @@ management:
       show-details: always
 
 resilience4j:
+  ratelimiter:
+    instances:
+      dnsResolve:
+        limitForPeriod: 1
+        limitRefreshPeriod: 1s
+        timeoutDuration: 0s
   retry:
     instances:
       fashion:

--- a/gateway/src/test/java/com/steadybit/demo/shopping/gateway/DnsControllerTest.java
+++ b/gateway/src/test/java/com/steadybit/demo/shopping/gateway/DnsControllerTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2026 steadybit GmbH. All rights reserved.
+ */
+
+package com.steadybit.demo.shopping.gateway;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(DnsController.class)
+class DnsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void shouldResolveValidHostname() throws Exception {
+        mockMvc.perform(post("/api/dns/resolve/localhost"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.hostname").value("localhost"))
+                .andExpect(jsonPath("$.addresses").isNotEmpty())
+                .andExpect(jsonPath("$.error").isEmpty());
+    }
+
+    @Test
+    void shouldReturnErrorForUnknownHostname() throws Exception {
+        mockMvc.perform(post("/api/dns/resolve/this.host.does.not.exist.invalid"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.hostname").value("this.host.does.not.exist.invalid"))
+                .andExpect(jsonPath("$.addresses").isEmpty())
+                .andExpect(jsonPath("$.error").isNotEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- Replace `RestTemplate` with `RestClient` across all gateway controllers
- Add `POST /api/dns/resolve/{hostname}` endpoint using Netty's `DnsNameResolver` for uncached DNS lookups
- Rate limit DNS endpoint to 1 req/s via Resilience4j `@RateLimiter`
- Add gateway test infrastructure and tests for the DNS endpoint

## Test plan
- [x] `mvn test -pl gateway -am` passes (2 tests)
- [x] Verify DNS resolve returns correct addresses for known hostnames
- [x] Verify rate limiter rejects requests exceeding 1/s with 429