### PR TITLE
build: upgrade Spring Boot to 4.0.7

### DIFF
--- a/bestseller-fashion/pom.xml
+++ b/bestseller-fashion/pom.xml
@@ -40,7 +40,6 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>${postgresql.version}</version>
         </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>

--- a/hot-deals/pom.xml
+++ b/hot-deals/pom.xml
@@ -40,7 +40,6 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>${postgresql.version}</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,11 +27,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>25</java.version>
-        <spring-boot.version>4.0.6</spring-boot.version>
+        <spring-boot.version>4.0.7</spring-boot.version>
         <lombok.version>1.18.46</lombok.version>
         <commons-lang3.version>3.20.0</commons-lang3.version> <!-- remove when spring boot contains this version -->
-        <postgresql.version>42.7.11</postgresql.version> <!-- remove when spring boot contains this version -->
-        <tomcat.version>11.0.22</tomcat.version> <!-- remove when spring boot contains this version -->
         <!--plugins-->
         <maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
@@ -42,42 +40,6 @@
     </properties>
     <dependencyManagement>
         <dependencies>
-            <!-- Tomcat overrides — remove when spring boot contains this version. -->
-            <dependency>
-                <groupId>org.apache.tomcat</groupId>
-                <artifactId>tomcat-annotations-api</artifactId>
-                <version>${tomcat.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat</groupId>
-                <artifactId>tomcat-jdbc</artifactId>
-                <version>${tomcat.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat</groupId>
-                <artifactId>tomcat-jsp-api</artifactId>
-                <version>${tomcat.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-core</artifactId>
-                <version>${tomcat.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-el</artifactId>
-                <version>${tomcat.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-jasper</artifactId>
-                <version>${tomcat.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.tomcat.embed</groupId>
-                <artifactId>tomcat-embed-websocket</artifactId>
-                <version>${tomcat.version}</version>
-            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>


### PR DESCRIPTION
## Summary
- Bump Spring Boot from 4.0.6 to 4.0.7 (latest 4.0.x patch).
- Drop `tomcat.version` (11.0.22) and `postgresql.version` (42.7.11) overrides — Spring Boot 4.0.7 manages exactly those versions.
- Keep `commons-lang3` override at 3.20.0 (Spring Boot 4.0.7 still ships 3.19.0).

## Test plan
- [ ] CI passes