### PR TITLE
build: drop stale netty BOM override in gateway

### DIFF
--- a/gateway/pom.xml
+++ b/gateway/pom.xml
@@ -16,18 +16,6 @@
     <artifactId>gateway</artifactId>
     <name>steadybit Shopping Demo - Gateway</name>
     <version>${revision}</version>
-    <dependencyManagement>
-        <dependencies>
-            <!-- remove when spring boot contains this version -->
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-bom</artifactId>
-                <version>4.2.13.Final</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>com.steadybit.demo.shopping</groupId>


### PR DESCRIPTION
## Summary
Follow-up to #175. `gateway/pom.xml` was importing `io.netty:netty-bom:4.2.13.Final`, which is now **older** than what Spring Boot 4.0.7 manages (`4.2.15.Final`). The override was actively holding netty back. Dropping it lets the parent BOM apply.

## Test plan
- [ ] CI passes