### PR TITLE
fix(shopping-ui): align jest-environment-jsdom with jest 30.4 core

### DIFF
--- a/shopping-ui/package-lock.json
+++ b/shopping-ui/package-lock.json
@@ -31,7 +31,7 @@
                 "@vitejs/plugin-react": "^5.1.4",
                 "identity-obj-proxy": "^3.0.0",
                 "jest": "^30.2.0",
-                "jest-environment-jsdom": "^30.2.0",
+                "jest-environment-jsdom": "^30.4.1",
                 "sass": "^1.57.1",
                 "ts-jest": "^29.4.6",
                 "ts-node": "^10.9.2",
@@ -1314,131 +1314,6 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
-        "node_modules/@jest/console/node_modules/@jest/pattern": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-            "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "jest-regex-util": "30.4.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/console/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/console/node_modules/@jest/types": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-            "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/pattern": "30.4.0",
-                "@jest/schemas": "30.4.1",
-                "@types/istanbul-lib-coverage": "^2.0.6",
-                "@types/istanbul-reports": "^3.0.4",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.33",
-                "chalk": "^4.1.2"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/console/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/@jest/console/node_modules/jest-message-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
-            "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@jest/types": "30.4.1",
-                "@types/stack-utils": "^2.0.3",
-                "chalk": "^4.1.2",
-                "graceful-fs": "^4.2.11",
-                "jest-util": "30.4.1",
-                "picomatch": "^4.0.3",
-                "pretty-format": "30.4.1",
-                "slash": "^3.0.0",
-                "stack-utils": "^2.0.6"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/console/node_modules/jest-regex-util": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/console/node_modules/jest-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
-            "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "chalk": "^4.1.2",
-                "ci-info": "^4.2.0",
-                "graceful-fs": "^4.2.11",
-                "picomatch": "^4.0.3"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/console/node_modules/pretty-format": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-            "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "30.4.1",
-                "ansi-styles": "^5.2.0",
-                "react-is-18": "npm:react-is@^18.3.1",
-                "react-is-19": "npm:react-is@^19.2.5"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
         "node_modules/@jest/core": {
             "version": "30.4.2",
             "resolved": "https://registry.npmjs.org/@jest/core/-/core-30.4.2.tgz",
@@ -1487,20 +1362,6 @@
                 }
             }
         },
-        "node_modules/@jest/core/node_modules/@jest/pattern": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-            "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "jest-regex-util": "30.4.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
         "node_modules/@jest/core/node_modules/@jest/schemas": {
             "version": "30.4.1",
             "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
@@ -1509,25 +1370,6 @@
             "license": "MIT",
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/core/node_modules/@jest/types": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-            "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/pattern": "30.4.0",
-                "@jest/schemas": "30.4.1",
-                "@types/istanbul-lib-coverage": "^2.0.6",
-                "@types/istanbul-reports": "^3.0.4",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.33",
-                "chalk": "^4.1.2"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -1544,56 +1386,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/@jest/core/node_modules/jest-message-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
-            "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@jest/types": "30.4.1",
-                "@types/stack-utils": "^2.0.3",
-                "chalk": "^4.1.2",
-                "graceful-fs": "^4.2.11",
-                "jest-util": "30.4.1",
-                "picomatch": "^4.0.3",
-                "pretty-format": "30.4.1",
-                "slash": "^3.0.0",
-                "stack-utils": "^2.0.6"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/core/node_modules/jest-regex-util": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/core/node_modules/jest-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
-            "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "chalk": "^4.1.2",
-                "ci-info": "^4.2.0",
-                "graceful-fs": "^4.2.11",
-                "picomatch": "^4.0.3"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
         "node_modules/@jest/core/node_modules/pretty-format": {
@@ -1623,35 +1415,35 @@
             }
         },
         "node_modules/@jest/environment": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
-            "integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
+            "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/fake-timers": "30.3.0",
-                "@jest/types": "30.3.0",
+                "@jest/fake-timers": "30.4.1",
+                "@jest/types": "30.4.1",
                 "@types/node": "*",
-                "jest-mock": "30.3.0"
+                "jest-mock": "30.4.1"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
         "node_modules/@jest/environment-jsdom-abstract": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.3.0.tgz",
-            "integrity": "sha512-0hNFs5N6We3DMCwobzI0ydhkY10sT1tZSC0AAiy+0g2Dt/qEWgrcV5BrMxPczhe41cxW4qm6X+jqZaUdpZIajA==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.4.1.tgz",
+            "integrity": "sha512-dSlKrqug3siYNHVnjwIldShY12wAH3spwRltO/+8VOjg0X+xEq7vOs3DbBs4LRKsu7OH+NUb9kuZUNBF9Ho3TA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/environment": "30.3.0",
-                "@jest/fake-timers": "30.3.0",
-                "@jest/types": "30.3.0",
+                "@jest/environment": "30.4.1",
+                "@jest/fake-timers": "30.4.1",
+                "@jest/types": "30.4.1",
                 "@types/jsdom": "^21.1.7",
                 "@types/node": "*",
-                "jest-mock": "30.3.0",
-                "jest-util": "30.3.0"
+                "jest-mock": "30.4.1",
+                "jest-util": "30.4.1"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -1694,18 +1486,18 @@
             }
         },
         "node_modules/@jest/fake-timers": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
-            "integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
+            "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/types": "30.3.0",
-                "@sinonjs/fake-timers": "^15.0.0",
+                "@jest/types": "30.4.1",
+                "@sinonjs/fake-timers": "^15.4.0",
                 "@types/node": "*",
-                "jest-message-util": "30.3.0",
-                "jest-mock": "30.3.0",
-                "jest-util": "30.3.0"
+                "jest-message-util": "30.4.1",
+                "jest-mock": "30.4.1",
+                "jest-util": "30.4.1"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -1737,41 +1529,7 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
-        "node_modules/@jest/globals/node_modules/@jest/environment": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
-            "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/fake-timers": "30.4.1",
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "jest-mock": "30.4.1"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/globals/node_modules/@jest/fake-timers": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
-            "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@sinonjs/fake-timers": "^15.4.0",
-                "@types/node": "*",
-                "jest-message-util": "30.4.1",
-                "jest-mock": "30.4.1",
-                "jest-util": "30.4.1"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/globals/node_modules/@jest/pattern": {
+        "node_modules/@jest/pattern": {
             "version": "30.4.0",
             "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
             "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
@@ -1780,146 +1538,6 @@
             "dependencies": {
                 "@types/node": "*",
                 "jest-regex-util": "30.4.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/globals/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/globals/node_modules/@jest/types": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-            "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/pattern": "30.4.0",
-                "@jest/schemas": "30.4.1",
-                "@types/istanbul-lib-coverage": "^2.0.6",
-                "@types/istanbul-reports": "^3.0.4",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.33",
-                "chalk": "^4.1.2"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/globals/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/@jest/globals/node_modules/jest-message-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
-            "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@jest/types": "30.4.1",
-                "@types/stack-utils": "^2.0.3",
-                "chalk": "^4.1.2",
-                "graceful-fs": "^4.2.11",
-                "jest-util": "30.4.1",
-                "picomatch": "^4.0.3",
-                "pretty-format": "30.4.1",
-                "slash": "^3.0.0",
-                "stack-utils": "^2.0.6"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/globals/node_modules/jest-mock": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
-            "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "jest-util": "30.4.1"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/globals/node_modules/jest-regex-util": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/globals/node_modules/jest-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
-            "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "chalk": "^4.1.2",
-                "ci-info": "^4.2.0",
-                "graceful-fs": "^4.2.11",
-                "picomatch": "^4.0.3"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/globals/node_modules/pretty-format": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-            "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "30.4.1",
-                "ansi-styles": "^5.2.0",
-                "react-is-18": "npm:react-is@^18.3.1",
-                "react-is-19": "npm:react-is@^19.2.5"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/pattern": {
-            "version": "30.0.1",
-            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
-            "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "jest-regex-util": "30.0.1"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -1968,131 +1586,6 @@
                 }
             }
         },
-        "node_modules/@jest/reporters/node_modules/@jest/pattern": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-            "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "jest-regex-util": "30.4.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/reporters/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/reporters/node_modules/@jest/types": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-            "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/pattern": "30.4.0",
-                "@jest/schemas": "30.4.1",
-                "@types/istanbul-lib-coverage": "^2.0.6",
-                "@types/istanbul-reports": "^3.0.4",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.33",
-                "chalk": "^4.1.2"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/reporters/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/@jest/reporters/node_modules/jest-message-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
-            "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@jest/types": "30.4.1",
-                "@types/stack-utils": "^2.0.3",
-                "chalk": "^4.1.2",
-                "graceful-fs": "^4.2.11",
-                "jest-util": "30.4.1",
-                "picomatch": "^4.0.3",
-                "pretty-format": "30.4.1",
-                "slash": "^3.0.0",
-                "stack-utils": "^2.0.6"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/reporters/node_modules/jest-regex-util": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/reporters/node_modules/jest-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
-            "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "chalk": "^4.1.2",
-                "ci-info": "^4.2.0",
-                "graceful-fs": "^4.2.11",
-                "picomatch": "^4.0.3"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/reporters/node_modules/pretty-format": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-            "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "30.4.1",
-                "ansi-styles": "^5.2.0",
-                "react-is-18": "npm:react-is@^18.3.1",
-                "react-is-19": "npm:react-is@^19.2.5"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
         "node_modules/@jest/schemas": {
             "version": "30.0.5",
             "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
@@ -2118,62 +1611,6 @@
                 "graceful-fs": "^4.2.11",
                 "natural-compare": "^1.4.0"
             },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/snapshot-utils/node_modules/@jest/pattern": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-            "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "jest-regex-util": "30.4.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/snapshot-utils/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/snapshot-utils/node_modules/@jest/types": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-            "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/pattern": "30.4.0",
-                "@jest/schemas": "30.4.1",
-                "@types/istanbul-lib-coverage": "^2.0.6",
-                "@types/istanbul-reports": "^3.0.4",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.33",
-                "chalk": "^4.1.2"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/snapshot-utils/node_modules/jest-regex-util": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-            "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
@@ -2205,62 +1642,6 @@
                 "@types/istanbul-lib-coverage": "^2.0.6",
                 "collect-v8-coverage": "^1.0.2"
             },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/test-result/node_modules/@jest/pattern": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-            "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "jest-regex-util": "30.4.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/test-result/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/test-result/node_modules/@jest/types": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-            "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/pattern": "30.4.0",
-                "@jest/schemas": "30.4.1",
-                "@types/istanbul-lib-coverage": "^2.0.6",
-                "@types/istanbul-reports": "^3.0.4",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.33",
-                "chalk": "^4.1.2"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/test-result/node_modules/jest-regex-util": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-            "dev": true,
-            "license": "MIT",
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
@@ -2307,34 +1688,7 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
-        "node_modules/@jest/transform/node_modules/@jest/pattern": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-            "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "jest-regex-util": "30.4.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/transform/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/transform/node_modules/@jest/types": {
+        "node_modules/@jest/types": {
             "version": "30.4.1",
             "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
             "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
@@ -2353,48 +1707,14 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
-        "node_modules/@jest/transform/node_modules/jest-regex-util": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/transform/node_modules/jest-util": {
+        "node_modules/@jest/types/node_modules/@jest/schemas": {
             "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
-            "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
+            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "chalk": "^4.1.2",
-                "ci-info": "^4.2.0",
-                "graceful-fs": "^4.2.11",
-                "picomatch": "^4.0.3"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/types": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
-            "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/pattern": "30.0.1",
-                "@jest/schemas": "30.0.5",
-                "@types/istanbul-lib-coverage": "^2.0.6",
-                "@types/istanbul-reports": "^3.0.4",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.33",
-                "chalk": "^4.1.2"
+                "@sinclair/typebox": "^0.34.0"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -5467,146 +4787,6 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
-        "node_modules/expect/node_modules/@jest/pattern": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-            "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "jest-regex-util": "30.4.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/expect/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/expect/node_modules/@jest/types": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-            "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/pattern": "30.4.0",
-                "@jest/schemas": "30.4.1",
-                "@types/istanbul-lib-coverage": "^2.0.6",
-                "@types/istanbul-reports": "^3.0.4",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.33",
-                "chalk": "^4.1.2"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/expect/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/expect/node_modules/jest-message-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
-            "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@jest/types": "30.4.1",
-                "@types/stack-utils": "^2.0.3",
-                "chalk": "^4.1.2",
-                "graceful-fs": "^4.2.11",
-                "jest-util": "30.4.1",
-                "picomatch": "^4.0.3",
-                "pretty-format": "30.4.1",
-                "slash": "^3.0.0",
-                "stack-utils": "^2.0.6"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/expect/node_modules/jest-mock": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
-            "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "jest-util": "30.4.1"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/expect/node_modules/jest-regex-util": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/expect/node_modules/jest-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
-            "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "chalk": "^4.1.2",
-                "ci-info": "^4.2.0",
-                "graceful-fs": "^4.2.11",
-                "picomatch": "^4.0.3"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/expect/node_modules/pretty-format": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-            "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "30.4.1",
-                "ansi-styles": "^5.2.0",
-                "react-is-18": "npm:react-is@^18.3.1",
-                "react-is-19": "npm:react-is@^19.2.5"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -6352,80 +5532,6 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
-        "node_modules/jest-changed-files/node_modules/@jest/pattern": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-            "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "jest-regex-util": "30.4.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-changed-files/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-changed-files/node_modules/@jest/types": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-            "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/pattern": "30.4.0",
-                "@jest/schemas": "30.4.1",
-                "@types/istanbul-lib-coverage": "^2.0.6",
-                "@types/istanbul-reports": "^3.0.4",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.33",
-                "chalk": "^4.1.2"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-changed-files/node_modules/jest-regex-util": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-changed-files/node_modules/jest-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
-            "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "chalk": "^4.1.2",
-                "ci-info": "^4.2.0",
-                "graceful-fs": "^4.2.11",
-                "picomatch": "^4.0.3"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
         "node_modules/jest-circus": {
             "version": "30.4.2",
             "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-30.4.2.tgz",
@@ -6458,54 +5564,6 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
-        "node_modules/jest-circus/node_modules/@jest/environment": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
-            "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/fake-timers": "30.4.1",
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "jest-mock": "30.4.1"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-circus/node_modules/@jest/fake-timers": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
-            "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@sinonjs/fake-timers": "^15.4.0",
-                "@types/node": "*",
-                "jest-message-util": "30.4.1",
-                "jest-mock": "30.4.1",
-                "jest-util": "30.4.1"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-circus/node_modules/@jest/pattern": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-            "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "jest-regex-util": "30.4.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
         "node_modules/jest-circus/node_modules/@jest/schemas": {
             "version": "30.4.1",
             "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
@@ -6514,25 +5572,6 @@
             "license": "MIT",
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-circus/node_modules/@jest/types": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-            "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/pattern": "30.4.0",
-                "@jest/schemas": "30.4.1",
-                "@types/istanbul-lib-coverage": "^2.0.6",
-                "@types/istanbul-reports": "^3.0.4",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.33",
-                "chalk": "^4.1.2"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -6549,71 +5588,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/jest-circus/node_modules/jest-message-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
-            "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@jest/types": "30.4.1",
-                "@types/stack-utils": "^2.0.3",
-                "chalk": "^4.1.2",
-                "graceful-fs": "^4.2.11",
-                "jest-util": "30.4.1",
-                "picomatch": "^4.0.3",
-                "pretty-format": "30.4.1",
-                "slash": "^3.0.0",
-                "stack-utils": "^2.0.6"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-circus/node_modules/jest-mock": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
-            "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "jest-util": "30.4.1"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-circus/node_modules/jest-regex-util": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-circus/node_modules/jest-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
-            "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "chalk": "^4.1.2",
-                "ci-info": "^4.2.0",
-                "graceful-fs": "^4.2.11",
-                "picomatch": "^4.0.3"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
         "node_modules/jest-circus/node_modules/pretty-format": {
@@ -6663,80 +5637,6 @@
                 "node-notifier": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/jest-cli/node_modules/@jest/pattern": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-            "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "jest-regex-util": "30.4.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-cli/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-cli/node_modules/@jest/types": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-            "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/pattern": "30.4.0",
-                "@jest/schemas": "30.4.1",
-                "@types/istanbul-lib-coverage": "^2.0.6",
-                "@types/istanbul-reports": "^3.0.4",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.33",
-                "chalk": "^4.1.2"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-cli/node_modules/jest-regex-util": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-cli/node_modules/jest-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
-            "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "chalk": "^4.1.2",
-                "ci-info": "^4.2.0",
-                "graceful-fs": "^4.2.11",
-                "picomatch": "^4.0.3"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
         "node_modules/jest-config": {
@@ -6790,20 +5690,6 @@
                 }
             }
         },
-        "node_modules/jest-config/node_modules/@jest/pattern": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-            "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "jest-regex-util": "30.4.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
         "node_modules/jest-config/node_modules/@jest/schemas": {
             "version": "30.4.1",
             "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
@@ -6812,25 +5698,6 @@
             "license": "MIT",
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-config/node_modules/@jest/types": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-            "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/pattern": "30.4.0",
-                "@jest/schemas": "30.4.1",
-                "@types/istanbul-lib-coverage": "^2.0.6",
-                "@types/istanbul-reports": "^3.0.4",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.33",
-                "chalk": "^4.1.2"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -6847,34 +5714,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/jest-config/node_modules/jest-regex-util": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-config/node_modules/jest-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
-            "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "chalk": "^4.1.2",
-                "ci-info": "^4.2.0",
-                "graceful-fs": "^4.2.11",
-                "picomatch": "^4.0.3"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
         "node_modules/jest-config/node_modules/pretty-format": {
@@ -6981,20 +5820,6 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
-        "node_modules/jest-each/node_modules/@jest/pattern": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-            "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "jest-regex-util": "30.4.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
         "node_modules/jest-each/node_modules/@jest/schemas": {
             "version": "30.4.1",
             "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
@@ -7003,25 +5828,6 @@
             "license": "MIT",
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-each/node_modules/@jest/types": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-            "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/pattern": "30.4.0",
-                "@jest/schemas": "30.4.1",
-                "@types/istanbul-lib-coverage": "^2.0.6",
-                "@types/istanbul-reports": "^3.0.4",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.33",
-                "chalk": "^4.1.2"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -7038,34 +5844,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/jest-each/node_modules/jest-regex-util": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-each/node_modules/jest-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
-            "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "chalk": "^4.1.2",
-                "ci-info": "^4.2.0",
-                "graceful-fs": "^4.2.11",
-                "picomatch": "^4.0.3"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
         "node_modules/jest-each/node_modules/pretty-format": {
@@ -7085,14 +5863,14 @@
             }
         },
         "node_modules/jest-environment-jsdom": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.3.0.tgz",
-            "integrity": "sha512-RLEOJy6ip1lpw0yqJ8tB3i88FC7VBz7i00Zvl2qF71IdxjS98gC9/0SPWYIBVXHm5hgCYK0PAlSlnHGGy9RoMg==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.4.1.tgz",
+            "integrity": "sha512-o3nfaN4zej7qgk2X0j8Jhq/S9nAVKs2xK3QeQxeHVvpkEPxaA1yxDGydR+iVI7zPy7Cp62Aq2h3Ja46QvfWHGA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/environment": "30.3.0",
-                "@jest/environment-jsdom-abstract": "30.3.0",
+                "@jest/environment": "30.4.1",
+                "@jest/environment-jsdom-abstract": "30.4.1",
                 "jsdom": "^26.1.0"
             },
             "engines": {
@@ -7126,180 +5904,6 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
-        "node_modules/jest-environment-node/node_modules/@jest/environment": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
-            "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/fake-timers": "30.4.1",
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "jest-mock": "30.4.1"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-environment-node/node_modules/@jest/fake-timers": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
-            "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@sinonjs/fake-timers": "^15.4.0",
-                "@types/node": "*",
-                "jest-message-util": "30.4.1",
-                "jest-mock": "30.4.1",
-                "jest-util": "30.4.1"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-environment-node/node_modules/@jest/pattern": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-            "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "jest-regex-util": "30.4.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-environment-node/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-environment-node/node_modules/@jest/types": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-            "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/pattern": "30.4.0",
-                "@jest/schemas": "30.4.1",
-                "@types/istanbul-lib-coverage": "^2.0.6",
-                "@types/istanbul-reports": "^3.0.4",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.33",
-                "chalk": "^4.1.2"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-environment-node/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/jest-environment-node/node_modules/jest-message-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
-            "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@jest/types": "30.4.1",
-                "@types/stack-utils": "^2.0.3",
-                "chalk": "^4.1.2",
-                "graceful-fs": "^4.2.11",
-                "jest-util": "30.4.1",
-                "picomatch": "^4.0.3",
-                "pretty-format": "30.4.1",
-                "slash": "^3.0.0",
-                "stack-utils": "^2.0.6"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-environment-node/node_modules/jest-mock": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
-            "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "jest-util": "30.4.1"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-environment-node/node_modules/jest-regex-util": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-environment-node/node_modules/jest-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
-            "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "chalk": "^4.1.2",
-                "ci-info": "^4.2.0",
-                "graceful-fs": "^4.2.11",
-                "picomatch": "^4.0.3"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-environment-node/node_modules/pretty-format": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-            "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "30.4.1",
-                "ansi-styles": "^5.2.0",
-                "react-is-18": "npm:react-is@^18.3.1",
-                "react-is-19": "npm:react-is@^19.2.5"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
         "node_modules/jest-haste-map": {
             "version": "30.4.1",
             "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-30.4.1.tgz",
@@ -7323,80 +5927,6 @@
             },
             "optionalDependencies": {
                 "fsevents": "^2.3.3"
-            }
-        },
-        "node_modules/jest-haste-map/node_modules/@jest/pattern": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-            "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "jest-regex-util": "30.4.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-haste-map/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-haste-map/node_modules/@jest/types": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-            "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/pattern": "30.4.0",
-                "@jest/schemas": "30.4.1",
-                "@types/istanbul-lib-coverage": "^2.0.6",
-                "@types/istanbul-reports": "^3.0.4",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.33",
-                "chalk": "^4.1.2"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-haste-map/node_modules/jest-regex-util": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-haste-map/node_modules/jest-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
-            "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "chalk": "^4.1.2",
-                "ci-info": "^4.2.0",
-                "graceful-fs": "^4.2.11",
-                "picomatch": "^4.0.3"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
         "node_modules/jest-leak-detector": {
@@ -7514,21 +6044,35 @@
             }
         },
         "node_modules/jest-message-util": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
-            "integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
+            "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
-                "@jest/types": "30.3.0",
+                "@jest/types": "30.4.1",
                 "@types/stack-utils": "^2.0.3",
                 "chalk": "^4.1.2",
                 "graceful-fs": "^4.2.11",
+                "jest-util": "30.4.1",
                 "picomatch": "^4.0.3",
-                "pretty-format": "30.3.0",
+                "pretty-format": "30.4.1",
                 "slash": "^3.0.0",
                 "stack-utils": "^2.0.6"
+            },
+            "engines": {
+                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+            }
+        },
+        "node_modules/jest-message-util/node_modules/@jest/schemas": {
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@sinclair/typebox": "^0.34.0"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -7548,37 +6092,31 @@
             }
         },
         "node_modules/jest-message-util/node_modules/pretty-format": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
-            "integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+            "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/schemas": "30.0.5",
+                "@jest/schemas": "30.4.1",
                 "ansi-styles": "^5.2.0",
-                "react-is": "^18.3.1"
+                "react-is-18": "npm:react-is@^18.3.1",
+                "react-is-19": "npm:react-is@^19.2.5"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
-        "node_modules/jest-message-util/node_modules/react-is": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/jest-mock": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
-            "integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
+            "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/types": "30.3.0",
+                "@jest/types": "30.4.1",
                 "@types/node": "*",
-                "jest-util": "30.3.0"
+                "jest-util": "30.4.1"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -7603,9 +6141,9 @@
             }
         },
         "node_modules/jest-regex-util": {
-            "version": "30.0.1",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
-            "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+            "version": "30.4.0",
+            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
+            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7646,90 +6184,6 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
-        "node_modules/jest-resolve-dependencies/node_modules/jest-regex-util": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-resolve/node_modules/@jest/pattern": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-            "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "jest-regex-util": "30.4.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-resolve/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-resolve/node_modules/@jest/types": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-            "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/pattern": "30.4.0",
-                "@jest/schemas": "30.4.1",
-                "@types/istanbul-lib-coverage": "^2.0.6",
-                "@types/istanbul-reports": "^3.0.4",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.33",
-                "chalk": "^4.1.2"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-resolve/node_modules/jest-regex-util": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-resolve/node_modules/jest-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
-            "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "chalk": "^4.1.2",
-                "ci-info": "^4.2.0",
-                "graceful-fs": "^4.2.11",
-                "picomatch": "^4.0.3"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
         "node_modules/jest-runner": {
             "version": "30.4.2",
             "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-30.4.2.tgz",
@@ -7759,180 +6213,6 @@
                 "jest-worker": "30.4.1",
                 "p-limit": "^3.1.0",
                 "source-map-support": "0.5.13"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-runner/node_modules/@jest/environment": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
-            "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/fake-timers": "30.4.1",
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "jest-mock": "30.4.1"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-runner/node_modules/@jest/fake-timers": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
-            "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@sinonjs/fake-timers": "^15.4.0",
-                "@types/node": "*",
-                "jest-message-util": "30.4.1",
-                "jest-mock": "30.4.1",
-                "jest-util": "30.4.1"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-runner/node_modules/@jest/pattern": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-            "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "jest-regex-util": "30.4.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-runner/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-runner/node_modules/@jest/types": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-            "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/pattern": "30.4.0",
-                "@jest/schemas": "30.4.1",
-                "@types/istanbul-lib-coverage": "^2.0.6",
-                "@types/istanbul-reports": "^3.0.4",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.33",
-                "chalk": "^4.1.2"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-runner/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/jest-runner/node_modules/jest-message-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
-            "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@jest/types": "30.4.1",
-                "@types/stack-utils": "^2.0.3",
-                "chalk": "^4.1.2",
-                "graceful-fs": "^4.2.11",
-                "jest-util": "30.4.1",
-                "picomatch": "^4.0.3",
-                "pretty-format": "30.4.1",
-                "slash": "^3.0.0",
-                "stack-utils": "^2.0.6"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-runner/node_modules/jest-mock": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
-            "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "jest-util": "30.4.1"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-runner/node_modules/jest-regex-util": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-runner/node_modules/jest-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
-            "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "chalk": "^4.1.2",
-                "ci-info": "^4.2.0",
-                "graceful-fs": "^4.2.11",
-                "picomatch": "^4.0.3"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-runner/node_modules/pretty-format": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-            "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "30.4.1",
-                "ansi-styles": "^5.2.0",
-                "react-is-18": "npm:react-is@^18.3.1",
-                "react-is-19": "npm:react-is@^19.2.5"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -7972,180 +6252,6 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
-        "node_modules/jest-runtime/node_modules/@jest/environment": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.4.1.tgz",
-            "integrity": "sha512-AK9yNRqgKxiabqMoe4oW+3/TSSeV8vkdC7BGaxZdU0AFXfOpofTLqdru2GXKZghP3sdgwE9XXpnVwfZ8JnFV4w==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/fake-timers": "30.4.1",
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "jest-mock": "30.4.1"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-runtime/node_modules/@jest/fake-timers": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.4.1.tgz",
-            "integrity": "sha512-iW5umdmfPeWzehrVhugFQZqCchSCud5S1l2YT0O9ZhjRR0ExclANDZkiSBwzqtnlOn0J1JXvO+HZ6rkuyOVOgQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@sinonjs/fake-timers": "^15.4.0",
-                "@types/node": "*",
-                "jest-message-util": "30.4.1",
-                "jest-mock": "30.4.1",
-                "jest-util": "30.4.1"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-runtime/node_modules/@jest/pattern": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-            "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "jest-regex-util": "30.4.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-runtime/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-runtime/node_modules/@jest/types": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-            "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/pattern": "30.4.0",
-                "@jest/schemas": "30.4.1",
-                "@types/istanbul-lib-coverage": "^2.0.6",
-                "@types/istanbul-reports": "^3.0.4",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.33",
-                "chalk": "^4.1.2"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-runtime/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/jest-runtime/node_modules/jest-message-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
-            "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@jest/types": "30.4.1",
-                "@types/stack-utils": "^2.0.3",
-                "chalk": "^4.1.2",
-                "graceful-fs": "^4.2.11",
-                "jest-util": "30.4.1",
-                "picomatch": "^4.0.3",
-                "pretty-format": "30.4.1",
-                "slash": "^3.0.0",
-                "stack-utils": "^2.0.6"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-runtime/node_modules/jest-mock": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
-            "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "jest-util": "30.4.1"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-runtime/node_modules/jest-regex-util": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-runtime/node_modules/jest-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
-            "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "chalk": "^4.1.2",
-                "ci-info": "^4.2.0",
-                "graceful-fs": "^4.2.11",
-                "picomatch": "^4.0.3"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-runtime/node_modules/pretty-format": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-            "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "30.4.1",
-                "ansi-styles": "^5.2.0",
-                "react-is-18": "npm:react-is@^18.3.1",
-                "react-is-19": "npm:react-is@^19.2.5"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
         "node_modules/jest-snapshot": {
             "version": "30.4.1",
             "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-30.4.1.tgz",
@@ -8179,20 +6285,6 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
-        "node_modules/jest-snapshot/node_modules/@jest/pattern": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-            "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "jest-regex-util": "30.4.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
         "node_modules/jest-snapshot/node_modules/@jest/schemas": {
             "version": "30.4.1",
             "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
@@ -8201,25 +6293,6 @@
             "license": "MIT",
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-snapshot/node_modules/@jest/types": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-            "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/pattern": "30.4.0",
-                "@jest/schemas": "30.4.1",
-                "@types/istanbul-lib-coverage": "^2.0.6",
-                "@types/istanbul-reports": "^3.0.4",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.33",
-                "chalk": "^4.1.2"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -8236,56 +6309,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/jest-snapshot/node_modules/jest-message-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
-            "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@jest/types": "30.4.1",
-                "@types/stack-utils": "^2.0.3",
-                "chalk": "^4.1.2",
-                "graceful-fs": "^4.2.11",
-                "jest-util": "30.4.1",
-                "picomatch": "^4.0.3",
-                "pretty-format": "30.4.1",
-                "slash": "^3.0.0",
-                "stack-utils": "^2.0.6"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-snapshot/node_modules/jest-regex-util": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-snapshot/node_modules/jest-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
-            "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "chalk": "^4.1.2",
-                "ci-info": "^4.2.0",
-                "graceful-fs": "^4.2.11",
-                "picomatch": "^4.0.3"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
         "node_modules/jest-snapshot/node_modules/pretty-format": {
@@ -8318,13 +6341,13 @@
             }
         },
         "node_modules/jest-util": {
-            "version": "30.3.0",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
-            "integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
+            "version": "30.4.1",
+            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
+            "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@jest/types": "30.3.0",
+                "@jest/types": "30.4.1",
                 "@types/node": "*",
                 "chalk": "^4.1.2",
                 "ci-info": "^4.2.0",
@@ -8353,20 +6376,6 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
-        "node_modules/jest-validate/node_modules/@jest/pattern": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-            "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "jest-regex-util": "30.4.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
         "node_modules/jest-validate/node_modules/@jest/schemas": {
             "version": "30.4.1",
             "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
@@ -8375,25 +6384,6 @@
             "license": "MIT",
             "dependencies": {
                 "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-validate/node_modules/@jest/types": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-            "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/pattern": "30.4.0",
-                "@jest/schemas": "30.4.1",
-                "@types/istanbul-lib-coverage": "^2.0.6",
-                "@types/istanbul-reports": "^3.0.4",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.33",
-                "chalk": "^4.1.2"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -8423,16 +6413,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/jest-validate/node_modules/jest-regex-util": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
         "node_modules/jest-validate/node_modules/pretty-format": {
@@ -8471,80 +6451,6 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
-        "node_modules/jest-watcher/node_modules/@jest/pattern": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-            "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "jest-regex-util": "30.4.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-watcher/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-watcher/node_modules/@jest/types": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-            "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/pattern": "30.4.0",
-                "@jest/schemas": "30.4.1",
-                "@types/istanbul-lib-coverage": "^2.0.6",
-                "@types/istanbul-reports": "^3.0.4",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.33",
-                "chalk": "^4.1.2"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-watcher/node_modules/jest-regex-util": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-watcher/node_modules/jest-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
-            "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "chalk": "^4.1.2",
-                "ci-info": "^4.2.0",
-                "graceful-fs": "^4.2.11",
-                "picomatch": "^4.0.3"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
         "node_modules/jest-worker": {
             "version": "30.4.1",
             "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-30.4.1.tgz",
@@ -8557,80 +6463,6 @@
                 "jest-util": "30.4.1",
                 "merge-stream": "^2.0.0",
                 "supports-color": "^8.1.1"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-worker/node_modules/@jest/pattern": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-            "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "jest-regex-util": "30.4.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-worker/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-worker/node_modules/@jest/types": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-            "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/pattern": "30.4.0",
-                "@jest/schemas": "30.4.1",
-                "@types/istanbul-lib-coverage": "^2.0.6",
-                "@types/istanbul-reports": "^3.0.4",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.33",
-                "chalk": "^4.1.2"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-worker/node_modules/jest-regex-util": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-worker/node_modules/jest-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
-            "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "chalk": "^4.1.2",
-                "ci-info": "^4.2.0",
-                "graceful-fs": "^4.2.11",
-                "picomatch": "^4.0.3"
             },
             "engines": {
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -8650,62 +6482,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
-            }
-        },
-        "node_modules/jest/node_modules/@jest/pattern": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-            "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "jest-regex-util": "30.4.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest/node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest/node_modules/@jest/types": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-            "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/pattern": "30.4.0",
-                "@jest/schemas": "30.4.1",
-                "@types/istanbul-lib-coverage": "^2.0.6",
-                "@types/istanbul-reports": "^3.0.4",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.33",
-                "chalk": "^4.1.2"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest/node_modules/jest-regex-util": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
         "node_modules/js-tokens": {
@@ -9133,9 +6909,9 @@
             }
         },
         "node_modules/nwsapi": {
-            "version": "2.2.23",
-            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
-            "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+            "version": "2.2.24",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+            "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
             "dev": true,
             "license": "MIT"
         },

--- a/shopping-ui/package.json
+++ b/shopping-ui/package.json
@@ -32,7 +32,7 @@
         "@vitejs/plugin-react": "^5.1.4",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^30.2.0",
-        "jest-environment-jsdom": "^30.2.0",
+        "jest-environment-jsdom": "^30.4.1",
         "sass": "^1.57.1",
         "ts-jest": "^29.4.6",
         "ts-node": "^10.9.2",


### PR DESCRIPTION
The npm dependency update bumped jest core to 30.4.2 but left jest-environment-jsdom at 30.3.0, whose bundled jest-mock lacks clearMocksOnScope. Tests failed to run with a TypeError. Pinning jest-environment-jsdom to ^30.4.1 realigns jest-mock and fixes the suite.