### PR TITLE
ci: run helm chart version-increment check only on PRs to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,16 @@ name: Build
 
 on:
   push:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'charts/**'
   workflow_dispatch:
 
 jobs:
   build:
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -171,6 +177,7 @@ jobs:
 
   build-fashion-lambda:
     name: "Build and Upload fashion-bestseller Lambda"
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -267,6 +274,8 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: make chartlint
+        env:
+          CHARTLINT_FLAGS: ${{ github.event_name == 'pull_request' && '' || '--check-version-increment=false' }}
 
   release-helm-chart:
     name: "Release Helm Chart"

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,10 @@ charttesting:
 		helm unittest $$dir; \
 	done
 
-## chartlint: Lint charts
+## chartlint: Lint charts (override CHARTLINT_FLAGS to pass extra ct flags)
 .PHONY: chartlint
 chartlint:
-	ct lint --config chartTesting.yaml
+	ct lint --config chartTesting.yaml $(CHARTLINT_FLAGS)
 
 ## chart-bump-version: Bump the patch version and optionally set the appVersion
 .PHONY: chart-bump-version


### PR DESCRIPTION
## Problem

`ct lint` runs on every push and compares HEAD against `main`. With the `on: push` trigger the `--check-version-increment` check:

- is a **no-op on main pushes** (main compared against itself), and
- produces **false failures on develop**, because the dev release packages a timestamped chart version (`${version}-develop.<timestamp>`) and never relies on `Chart.yaml` being bumped.

This surfaced when develop and main both sat at chart `1.3.1` (main was released independently before a develop push), so `ct` flagged "chart version not ok. Needs a version bump!" even though the chart content was identical.

## Change

No new workflow — handled with conditionals inside `build.yml`:

- Add a `pull_request` trigger scoped to `main` + `charts/**`.
- Skip the heavy `build` and `build-fashion-lambda` jobs on `pull_request` runs (`docker-image` / deploy cascade-skip via `needs`), so chart PRs don't drag in the full matrix.
- Toggle `--check-version-increment` via `CHARTLINT_FLAGS`: enforced on PRs to main, disabled on pushes.
- `Makefile`: `chartlint` now accepts `CHARTLINT_FLAGS`.

## Behavior

| Event | Chart lint | Version-increment |
|---|---|---|
| push to develop | runs | skipped |
| push to main | runs | skipped (was a no-op) |
| PR → main touching charts/** | runs (chart job only) | enforced |

Release jobs are gated on branch ref and never fire on `pull_request`, so releases are unaffected.