### PR TITLE
ci: migrate to npm 12

### DIFF
--- a/.github/workflows/advice.yml
+++ b/.github/workflows/advice.yml
@@ -12,7 +12,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Steadybit CLI
-        run: npm install -g steadybit
+        run: |
+          npm install -g npm@12
+          npm install -g steadybit
         shell: bash
 
       - name: Add Mask

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,11 +28,12 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: '22.22'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: |
             shopping-ui/package-lock.json
 
+      - run: npm install -g npm@12
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
@@ -191,10 +192,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: v20
+          node-version: 24
           cache: 'npm'
           cache-dependency-path: |
             bestseller-fashion-lambda/package-lock.json
+      - run: npm install -g npm@12
       - run: npm install
         working-directory: bestseller-fashion-lambda
       - name: "[main] setup snyk"

--- a/.github/workflows/run-experiments.yml
+++ b/.github/workflows/run-experiments.yml
@@ -13,7 +13,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install Steadybit CLI
-        run: npm install -g steadybit
+        run: |
+          npm install -g npm@12
+          npm install -g steadybit
         shell: bash
 
       - name: Add Mask


### PR DESCRIPTION
npm 12 disables dependency install scripts (plus git and remote-URL dependencies) by default — see the [npm v12.0.0 release notes](https://github.com/npm/cli/releases/tag/v12.0.0). This migrates CI to npm 12.

- `build.yml` (UI job): loosen `node-version` from `22.22` to `22` — npm 12 requires `^22.22.2`, and pinning the minor risks falling below that floor; install npm 12 after `setup-node`.
- `build.yml` (lambda job): bump Node 20 → 24 (npm 12 refuses Node 20; Node 20 is EOL) and install npm 12. If the Lambda still runs on `nodejs20.x`, consider bumping the function runtime as well.
- `advice.yml` / `run-experiments.yml`: upgrade to npm 12 before installing the Steadybit CLI.

Verified against both lockfiles: all install scripts are binary-fallback postinstalls (@parcel/watcher, esbuild, fsevents, unrs-resolver) resolved via `optionalDependencies` — safe to leave blocked. No git or remote-URL dependencies.

Part of the org-wide npm 12 CI migration.
